### PR TITLE
Add alternate configuration for a shardset

### DIFF
--- a/sharded/README.md
+++ b/sharded/README.md
@@ -1,0 +1,43 @@
+homebrew-mongodb
+================
+
+Simple setup scripts to get a mongodb replica set up and running on OSX for development work.
+
+### Requirements
+* Homebrew installed. You can find it at [http://brew.sh/](http://brew.sh/)
+* mongodb installed
+
+You can install mongodb with the following command in terminal:
+``` pre
+brew install mongodb
+```
+
+### Files
+
+* homebrew.mxcl.mongodb#.plist
+* mongod#.conf
+
+### Directories Created
+* /usr/local/var/log/mongodb#/
+* /usr/local/var/mongodb#/
+
+Note: *# == 1,2,3*
+
+### Usage
+Run the following commands in terminal:
+``` pre
+git clone https://github.com/Icehunter/homebrew-mongodb.git
+cd homebrew-mongodb
+./setup.sh
+```
+### Verification
+You can verify your install by opening a mongo prompt with:
+``` pre
+mongo
+```
+It should say the following at the mongo prompt:
+``` pre
+rs.PRIMARY>
+```
+
+Congratulations! You now have a working local replica set with mongodb.

--- a/sharded/homebrew.mxcl.mongodb1.plist
+++ b/sharded/homebrew.mxcl.mongodb1.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>homebrew.mxcl.mongodb1</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/opt/mongodb/bin/mongod</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>/usr/local/etc/mongod1.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/mongodb/output_1.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/mongodb/output_1.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+</dict>
+</plist>

--- a/sharded/homebrew.mxcl.mongodb2.plist
+++ b/sharded/homebrew.mxcl.mongodb2.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>homebrew.mxcl.mongodb2</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/opt/mongodb/bin/mongod</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>/usr/local/etc/mongod2.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/mongodb/output_2.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/mongodb/output_2.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+</dict>
+</plist>
+

--- a/sharded/homebrew.mxcl.mongodb_shardconfig.plist
+++ b/sharded/homebrew.mxcl.mongodb_shardconfig.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>homebrew.mxcl.mongodb_shardconfig</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/opt/mongodb/bin/mongod</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>/usr/local/etc/mongod_shardconfig.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/mongodb/output_shardconfig.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/mongodb/output_shardconfig.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+</dict>
+</plist>
+
+

--- a/sharded/homebrew.mxcl.mongos.plist
+++ b/sharded/homebrew.mxcl.mongos.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>homebrew.mxcl.mongos</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/opt/mongodb/bin/mongos</string>
+    <string>--config</string>
+    <string>/usr/local/etc/mongos.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/mongodb/output_mongos.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/mongodb/output_mongos.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>1024</integer>
+  </dict>
+</dict>
+</plist>
+
+
+

--- a/sharded/mongod1.conf
+++ b/sharded/mongod1.conf
@@ -1,0 +1,21 @@
+systemLog:
+    destination: file
+    path: "/usr/local/var/log/mongodb/mongo_1.log"
+    quiet: true
+    logAppend: true
+storage:
+    journal:
+       enabled: true
+    engine: wiredTiger
+    dbPath: "/usr/local/var/mongodb_1"
+    wiredTiger:
+        collectionConfig:
+            blockCompressor: snappy
+        engineConfig:
+            directoryForIndexes: true
+processManagement:
+   fork: true
+net:
+   port: 27027
+sharding:
+    clusterRole: shardsvr

--- a/sharded/mongod2.conf
+++ b/sharded/mongod2.conf
@@ -1,0 +1,21 @@
+systemLog:
+    destination: file
+    path: "/usr/local/var/log/mongodb/mongo_2.log"
+    quiet: true
+    logAppend: true
+storage:
+    journal:
+       enabled: true
+    engine: wiredTiger
+    dbPath: "/usr/local/var/mongodb_2"
+    wiredTiger:
+        collectionConfig:
+            blockCompressor: snappy
+        engineConfig:
+            directoryForIndexes: true
+processManagement:
+   fork: true
+net:
+   port: 27028
+sharding:
+    clusterRole: shardsvr

--- a/sharded/mongod_shardconfig.conf
+++ b/sharded/mongod_shardconfig.conf
@@ -1,0 +1,16 @@
+systemLog:
+    destination: file
+    path: "/usr/local/var/log/mongodb/mongo_shardconfig.log"
+    quiet: true
+    logAppend: true
+storage:
+    journal:
+       enabled: true
+    dbPath: "/usr/local/var/mongodb_shardconfig"
+processManagement:
+    fork: true
+net:
+    port: 27019
+sharding:
+    clusterRole: configsvr
+    archiveMovedChunks: false

--- a/sharded/mongos.conf
+++ b/sharded/mongos.conf
@@ -1,0 +1,12 @@
+sharding:
+    configDB: "localhost:27019"
+    autoSplit: true
+systemLog:
+    destination: file
+    path: "/usr/local/var/log/mongodb/mongos.log"
+    quiet: true
+    logAppend: true
+processManagement:
+   fork: true
+net:
+   port: 27017

--- a/sharded/setup.sh
+++ b/sharded/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh -x
+
+# first unload/stop mongod instances
+launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongos.plist
+launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb1.plist
+launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb2.plist
+launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb_shardconfig.plist
+
+# stop the original if it's running
+launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb.plist
+
+pkill -f mongod
+
+# Remove any current mongod launchagents
+rm -f ~/Library/LaunchAgents/homebrew.mxcl.mongo*.plist
+
+# Install these mongod launchagents
+cp -f *.plist /usr/local/opt/mongodb/
+cp -f *.conf /usr/local/etc/
+cp -f shardset /usr/local/bin/
+
+# Make sure the log and data directories exist
+mkdir -p /usr/local/var/log/mongodb
+mkdir -p /usr/local/var/mongodb_1
+mkdir -p /usr/local/var/mongodb_2
+mkdir -p /usr/local/var/mongodb_shardconfig/
+
+# Put the launchagents in place
+ln -sfv /usr/local/opt/mongodb/homebrew.mxcl.mongo*.plist ~/Library/LaunchAgents/
+
+# Make sure the original plist isn't there, since this overrides it =]
+rm -f ~/Library/LaunchAgents/homebrew.mxcl.mongodb.plist
+
+# Kill any lock files that haven't been cleaned up
+rm -f /usr/local/var/mongodb_1/*.lock
+rm -f /usr/local/var/mongodb_2/*.lock
+rm -f /usr/local/var/mongodb_shardconfig/*.lock
+
+# load/start mongod and mongos instances
+launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb_shardconfig.plist
+launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb1.plist
+launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb2.plist
+launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongos.plist
+
+echo "Waiting for servers to be started..."
+sleep 10
+
+mongo --host 127.0.0.1 <<EOF
+
+sh.addShard("127.0.0.1:27027");
+sh.addShard("127.0.0.1:27028");
+
+EOF

--- a/sharded/shardset
+++ b/sharded/shardset
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+if [ "$#" -eq 1 ]; then
+  if [ "$1" == start ] || [ "$1" == stop ] || [ "$1" == restart ]; then
+    control_type=$1
+  else
+    echo "Usage: $0 start|stop|restart"
+    exit
+  fi
+else
+  echo "Usage: $0 start|stop|restart"
+  exit
+fi
+
+if [ "$control_type" == stop ] || [ "$control_type" == restart ]; then
+  echo "Stopping MongoDB instances"
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb1.plist
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb2.plist
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongos.plist
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.mongodb_shardconfig.plist
+  pkill -f mongod
+fi
+
+if [ "$control_type" == start ] || [ "$control_type" == restart ]; then
+  echo "Starting MongoDB instances"
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb1.plist
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb2.plist
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongos.plist
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mongodb_shardconfig.plist
+fi


### PR DESCRIPTION
In case you're interested, I added a subdir with a shard configuration.  it works exactly the same way, just creates 2 shards (not replicaset shards), a single config server, and a mongos instance on the 27017 default port.  Great for testing sharded configurations.
